### PR TITLE
バグ対応

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gas-team-builder",
   "private": true,
-  "version": "0.0.0",
+  "version": "1.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/server/code.ts
+++ b/server/code.ts
@@ -11,7 +11,7 @@ function getValues(spreadSheetId: string, sheetName: string) {
     return;
   }
 
-  return sheet.getDataRange().getValues();
+  return sheet.getDataRange().getDisplayValues();
 }
 
 export { getValues };

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -29,8 +29,21 @@ export default function App() {
   }
 
   function outputGroups() {
-    alert(JSON.stringify(groups));
+    if (!navigator.clipboard) {
+      alert("sorry. we can't copy in clipboard.");
+      return;
+    }
+
+    navigator.clipboard.writeText(JSON.stringify(groups)).then(
+      () => {
+        alert("we success in copying at clipboard.");
+      },
+      () => {
+        alert("sorry. we can't copy in clipboard.");
+      },
+    );
   }
+
   return (
     <>
       <Header

--- a/src/components/Content/Content.module.scss
+++ b/src/components/Content/Content.module.scss
@@ -12,6 +12,7 @@
       flex-direction: row;
       flex-wrap: wrap;
       gap: 8px;
+      min-height: 25px;
     }
 
     > .tag-sub-box {
@@ -19,6 +20,7 @@
       flex-direction: row;
       flex-wrap: wrap;
       gap: 8px;
+      min-height: 25px;
     }
   }
 

--- a/src/components/Content/Content.tsx
+++ b/src/components/Content/Content.tsx
@@ -54,7 +54,7 @@ export default function Content({
           : prev.map((group) => {
               const subTags = group.sub.filter(
                 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                (_tag, index) => droppedTag.id !== String(index),
+                (tag) => droppedTag.id !== tag.id,
               );
               return {
                 main: group.main,
@@ -73,7 +73,7 @@ export default function Content({
             return (
               <Tag
                 key={`main-tag${mainTag.id}`}
-                id={mainTag.id || ""}
+                id={mainTag.id || "0"}
                 text={mainTag.name || ""}
                 isMainTag
                 info={mainTag.info}
@@ -86,7 +86,7 @@ export default function Content({
             return (
               <Tag
                 key={`sub-tag${subTag.id}`}
-                id={subTag.id || ""}
+                id={subTag.id || "0"}
                 text={subTag.name || ""}
                 info={subTag.info}
               />

--- a/src/components/Group/Group.tsx
+++ b/src/components/Group/Group.tsx
@@ -50,7 +50,7 @@ export default function Group({
             <GroupCell
               text={group.main?.name || ""}
               groupNumber={componentId}
-              cellNumber={group.main.id}
+              cellNumber={group.main.id || "1"}
               isMain
               info={group.main.info}
               setMainTags={setMainTags}
@@ -68,7 +68,7 @@ export default function Group({
                 <GroupCell
                   text={tag.name || ""}
                   groupNumber={componentId}
-                  cellNumber={String(index)}
+                  cellNumber={tag.id || "1"}
                   info={tag.info}
                   setMainTags={setMainTags}
                   setSubTags={setSubTags}

--- a/src/components/Group/GroupCell.tsx
+++ b/src/components/Group/GroupCell.tsx
@@ -9,7 +9,7 @@ import Tag from "~/components/Tag/Tag";
 type Props = {
   text: string;
   groupNumber: number;
-  cellNumber?: string;
+  cellNumber: string;
   isMain?: boolean;
   info?: {
     header: string;
@@ -49,13 +49,13 @@ export function GroupCell({
             }
             droppedGroup.main = droppedTag;
           } else {
-            if (!!droppedGroup.sub[Number(cellNumber)].name && setSubTags) {
+            if (!!droppedGroup.sub[Number(cellNumber) - 1].name && setSubTags) {
               setSubTags((prev) => [
                 ...prev,
-                droppedGroup.sub[Number(cellNumber)],
+                droppedGroup.sub[Number(cellNumber) - 1],
               ]);
             }
-            droppedGroup.sub[Number(cellNumber)] = droppedTag;
+            droppedGroup.sub[Number(cellNumber) - 1] = droppedTag;
           }
 
           const removedGroups = prev.filter(
@@ -95,12 +95,7 @@ export function GroupCell({
     >
       <div className={styles.tagBox}>
         {text ? (
-          <Tag
-            id={cellNumber || "0"}
-            text={text}
-            isMainTag={isMain}
-            info={info}
-          />
+          <Tag id={cellNumber} text={text} isMainTag={isMain} info={info} />
         ) : (
           <div className={styles.tag} />
         )}

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -31,7 +31,7 @@ export default function Tag({ id, text, isMainTag = false, info }: Props) {
         isDragging: !!monitor.isDragging(),
       }),
     }),
-    [id, text, isMainTag],
+    [id, text, isMainTag, info],
   );
 
   return (


### PR DESCRIPTION
## 目的

<!-- このP-Rの目的を記載してください -->

- リリース後に見つかったバグの対応

## 概要

<!-- このP-Rの概要を記載してください -->

- getValues()だと、セルの表示形式によっては値が取得できなくなってしまうので、getDisplayValues()に修正する。
- グループから外せない。
- mainTagもしくはsubTagがなくなるとグループから外せなくなる。
- 出力するデータが長すぎると、window.alertだとすべて表示できなくなる場合があるので、出力形式を変更する。


## 共有項目

<!-- このP-Rで共有した項目を記載してください -->

- 特になし
